### PR TITLE
oss: fix "multiple definition of ..."

### DIFF
--- a/media-sound/oss/oss-4.2.2011.ebuild
+++ b/media-sound/oss/oss-4.2.2011.ebuild
@@ -79,6 +79,10 @@ src_prepare() {
 	sed -e "/^.*flashsupport.c .*/d" \
 		-i "${S}/setup/Linux/build.sh" \
 		-i "${S}/setup/Linux/oss/build/install.sh" || die
+
+	# fix "multiple definition of ..."
+	sed -e "s/extern inline/static inline/g" \
+		-i "${S}/kernel/OS/Linux/os_linux.h" || die
 }
 
 src_configure() {


### PR DESCRIPTION
I got an error with gcc-5.3.0
[build.log.txt](https://github.com/funtoo/funtoo-media/files/141612/build.log.txt)
Using "static inline" instead of "extern inline" solved the problem.